### PR TITLE
Update release workflow to use modern action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,21 +21,9 @@ jobs:
         pip install build
     - name: Build package
       run: python -m build
-    - name: Create Release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
-        draft: false
-        prerelease: false
-    - name: Upload Release Asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./dist/git-tui-${{ github.ref_name }}.tar.gz
-        asset_name: git-tui-${{ github.ref_name }}.tar.gz
-        asset_content_type: application/gzip
+     - name: Create Release
+       uses: softprops/action-gh-release@v1
+       with:
+         files: ./dist/git-tui-${{ github.ref_name }}.tar.gz
+       env:
+         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Updated the release workflow to use softprops/action-gh-release@v1 instead of deprecated actions/create-release@v1 and actions/upload-release-asset@v1. This resolves the 'Resource not accessible by integration' error by using a supported action for creating releases and uploading assets.