### PR TITLE
Fix invalid GitHub Actions expression for tag name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,10 @@ jobs:
   release:
     runs-on: ubuntu-latest
 
-    steps:
+     steps:
       - uses: actions/checkout@v4
+      - name: Set tag name
+        run: echo "TAG=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -24,6 +26,6 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
-          files: ./dist/git-tui-${{ github.ref_name | replace('v', '') }}.tar.gz
+          files: ./dist/git-tui-${{ env.TAG }}.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Replace the unsupported | replace filter with a shell command to set an env var for the tag name without 'v'.