### PR TITLE
Add troubleshooting section for file visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ pip install .
 
 python main.py
 
+## Troubleshooting
+
+If files or folders are not visible (especially hidden files starting with .), on macOS:
+
+- In Finder: Press Cmd + Shift + . to toggle hidden files.
+- Or via Terminal: `defaults write com.apple.finder AppleShowAllFiles YES; killall Finder`
+
 ## Docker
 
 Build and run with Docker Compose:

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ python main.py
 
 If files or folders are not visible (especially hidden files starting with .), on macOS:
 
-- In Finder: Press Cmd + Shift + . to toggle hidden files.
-- Or via Terminal: `defaults write com.apple.finder AppleShowAllFiles YES; killall Finder`
+- In Finder: Press `Cmd` + `Shift` + `.` to temporarily toggle hidden files.
+- Via Terminal (persistent): `defaults write com.apple.finder AppleShowAllFiles YES && killall Finder`. To hide again, replace `YES` with `NO`.
 
 ## Docker
 


### PR DESCRIPTION
## Summary
- Added a troubleshooting section to README.md explaining how to show hidden files on macOS.
- This helps users who may not see files starting with '.' in their file managers.